### PR TITLE
stripe: Refactor API calls

### DIFF
--- a/src/stripe/customers.js
+++ b/src/stripe/customers.js
@@ -1,62 +1,59 @@
 const stripe = require("./config");
 
-const getAllCustomers = async (limit = 10) => {
-  const customers = await stripe.customers.list({
-    limit: limit,
-  });
-  return customers;
+const getAllCustomers = async (req, res) => {
+  try {
+    const customers = await stripe.customers.list({
+      limit: req.query.limit,
+    });
+    res.send(customers);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
-const createSingleCustomer = async (
-  name,
-  desc,
-  address,
-  phone,
-  email,
-  currency,
-  invoice_settings,
-  invoice_prefix
-) => {
-  const customer = await stripe.customers.create({
-    name: name,
-    description: desc,
-    address: address,
-    phone: phone,
-    email: email,
-    currency: currency,
-    invoice_settings: invoice_settings,
-    invoice_prefix: invoice_prefix,
-  });
-  return customer;
+const createSingleCustomer = async (req, res) => {
+  try {
+    const customer = await stripe.customers.create({
+      name: req.body.name,
+      description: req.body.desc,
+      address: req.body.address,
+      phone: req.body.phone,
+      email: req.body.email,
+      currency: req.body.currency,
+      invoice_settings: req.body.invoice_settings,
+      invoice_prefix: req.body.invoice_prefix,
+    });
+    res.send(customer);
+  } catch(err) {
+    console.error(err);
+  }
 };
 
-const updateSingleCustomer = async (
-  id,
-  name,
-  desc,
-  address,
-  phone,
-  email,
-  currency,
-  invoice_settings,
-  invoice_prefix
-) => {
-  const customer = await stripe.customers.update(id, {
-    name: name,
-    description: desc,
-    address: address,
-    phone: phone,
-    email: email,
-    currency: currency,
-    invoice_settings: invoice_settings,
-    invoice_prefix: invoice_prefix,
-  });
-  return customer;
+const updateSingleCustomer = async (req, res) => {
+  try {
+    const customer = await stripe.customers.update(req.params.id, {
+      name: req.body.name,
+      description: req.body.desc,
+      address: req.body.address,
+      phone: req.body.phone,
+      email: req.body.email,
+      currency: req.body.currency,
+      invoice_settings: req.body.invoice_settings,
+      invoice_prefix: req.body.invoice_prefix,
+    });
+    res.send(customer);
+  } catch(err) {
+    console.error(err);
+  }
 };
 
-const deleteSingleCustomer = async (id) => {
-  const customer = await stripe.customers.del(id);
-  return customer;
+const deleteSingleCustomer = async (req, res) => {
+  try {
+    const customer = await stripe.customers.del(req.params.id);
+    res.send(customer);
+  } catch(err) {
+    console.error(err)
+  }
 };
 
 module.exports = {

--- a/src/stripe/prices.js
+++ b/src/stripe/prices.js
@@ -1,54 +1,49 @@
 const stripe = require("./config");
 
-const getAllPrices = async (product = "", limit = 10) => {
-  const prices = await stripe.prices.list({
-    product: product,
-    limit: limit,
-  });
-  return prices;
+const getAllPrices = async (req, res) => {
+  try {
+    const prices = await stripe.prices.list({
+      product: req.query.product,
+      limit: req.query.limit,
+    });
+    res.send(prices);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
-const createSinglePrice = async (
-  nickname,
-  active,
-  currency,
-  product,
-  reccuring,
-  type,
-  unit_amount
-) => {
-  const price = await stripe.prices.create({
-    nickname: nickname,
-    active: active,
-    currency: currency,
-    product: product,
-    reccuring: reccuring,
-    type: type,
-    unit_amount: unit_amount,
-  });
-  return price;
+const createSinglePrice = async (req, res) => {
+  try {
+    const price = await stripe.prices.create({
+      nickname: req.body.nickname,
+      active: req.body.active,
+      currency: req.body.currency,
+      product: req.body.product,
+      reccuring: req.body.reccuring,
+      type: req.body.type,
+      unit_amount: req.body.unit_amount,
+    });
+    res.sent(price);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
-const updateSinglePrice = async (
-  id,
-  nickname,
-  active,
-  currency,
-  product,
-  reccuring,
-  type,
-  unit_amount
-) => {
-  const price = await stripe.prices.update(id, {
-    nickname: nickname,
-    active: active,
-    currency: currency,
-    product: product,
-    reccuring: reccuring,
-    type: type,
-    unit_amount: unit_amount,
-  });
-  return price;
+const updateSinglePrice = async (req, res) => {
+  try {
+    const price = await stripe.prices.update(req.params.id, {
+      nickname: req.body.nickname,
+      active: req.body.active,
+      currency: req.body.currency,
+      product: req.body.product,
+      reccuring: req.body.reccuring,
+      type: req.body.type,
+      unit_amount: req.body.unit_amount,
+    });
+    res.send(price);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
 module.exports = {

--- a/src/stripe/products.js
+++ b/src/stripe/products.js
@@ -1,55 +1,76 @@
 const stripe = require("./config");
 
-const { getAllPrices } = require("./prices");
-
-const getAllProducts = async (limit=10) => {
-  const products = await stripe.products.list({
-    limit: limit
-  });
-  return products;
+const getAllProducts = async (req, res) => {
+  try {
+    const products = await stripe.products.list({
+      limit: req.query.limit
+    });
+    res.send(products);
+  } catch(err) {
+    console.error(err);
+  }
 };
 
-const getSingleProduct = async (id) => {
-  const product = await stripe.products.retrieve(id);
-  const prices = await getAllPrices(id);
-  product.prices = prices.data;
-  return product;
+const getSingleProduct = async (req, res) => {
+  try {
+    const product = await stripe.products.retrieve(req.params.id);
+    const prices = await stripe.prices.list({
+      product: req.params.id,
+      limit: req.query.limit,
+    });
+    product.prices = prices.data;
+    res.send(product);
+  } catch(err) {
+    console.error(err);
+  }
 };
 
-const createSingleProduct = async (name, desc, active, owner, address, utilities) => {
-  const product = await stripe.products.create({
-    name: name,
-    description: desc,
-    active: active,
-    metadata: {
-      owner: owner,
-      address: address,
-      utilities: utilities
-    }
-  });
-  return product;
-}
-
-const updateSingleProduct = async (id, name, desc, active, owner, address, utilities) => {
-  const product = await stripe.products.update(
-    id,
-    {
-      name: name,
-      description: desc,
-      active: active,
+const createSingleProduct = async (req, res) => {
+  try {
+    const product = await stripe.products.create({
+      name: req.body.name,
+      description: req.body.desc,
+      active: req.body.active,
       metadata: {
-        owner: owner,
-        address: address,
-        utilities: utilities
+        owner: req.body.owner,
+        address: req.body.address,
+        utilities: req.body.utilities
       }
-    }
-  );
-  return product;
+    });
+    res.send(product);
+  } catch (err) {
+    console.error(err);
+  }
 }
 
-const deleteSingleProduct = async (id) => {
-  const product = await stripe.products.del(id);
-  return product;
+const updateSingleProduct = async (req, res) => {
+  try {
+    const product = await stripe.products.update(
+      req.params.id,
+      {
+        name: req.body.name,
+        description: req.body.desc,
+        active: req.body.active,
+        metadata: {
+          owner: req.body.owner,
+          address: req.body.address,
+          utilities: req.body.utilities
+        }
+      }
+    );
+    res.send(product);
+  } catch(err) {
+    console.error(err);
+  }
+}
+
+const deleteSingleProduct = async (req, res) => {
+  try {
+    const product = await stripe.products.del(req.params.id);
+    res.send(product);
+  } catch(err) {
+    console.error(err);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Functions managing API calls were unusable by the frontend. They now
can be used by making HTTP requests to endpoints.

resolving #5